### PR TITLE
Behebt einen Fehler, dass die Webjars nicht aufzurufen waren. Ursache…

### DIFF
--- a/Tournament-Planner/pom.xml
+++ b/Tournament-Planner/pom.xml
@@ -56,6 +56,11 @@
 		    <groupId>org.thymeleaf.extras</groupId>
 		    <artifactId>thymeleaf-extras-springsecurity5</artifactId>
 		    </dependency>
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>bootstrap</artifactId>
+			<version>4.3.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/Tournament-Planner/src/main/java/com/agil/config/AppConfiguration.java
+++ b/Tournament-Planner/src/main/java/com/agil/config/AppConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.agil.utility.GameType;
@@ -17,6 +18,13 @@ import com.agil.utility.GameType;
 @EnableWebMvc
 @ComponentScan
 public class AppConfiguration implements WebMvcConfigurer {
+
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry
+				.addResourceHandler("/webjars/**")
+				.addResourceLocations("/webjars/");
+	}
 
 	@Override
 	public void addFormatters(FormatterRegistry registry) {

--- a/Tournament-Planner/src/main/java/com/agil/config/WebSecurityConfig.java
+++ b/Tournament-Planner/src/main/java/com/agil/config/WebSecurityConfig.java
@@ -28,7 +28,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http.authorizeRequests()
-		.antMatchers("/registration").permitAll()
+				.antMatchers("/registration").permitAll()
+				.antMatchers("/webjars/**").permitAll()
 		.antMatchers("/teams/**").permitAll()
 		.antMatchers("/games/**").permitAll()
 		.antMatchers("/api/**").permitAll()

--- a/Tournament-Planner/src/main/java/com/agil/controller/MemberController.java
+++ b/Tournament-Planner/src/main/java/com/agil/controller/MemberController.java
@@ -71,7 +71,7 @@ public class MemberController {
 		return "registration";
 	}
 
-	@PostMapping
+	@PostMapping("/registration")
 	@PreAuthorize("hasRole('ROLE_ANONYMOUS')")
 	public String registration(@Valid @ModelAttribute("memberForm") Member memberForm, BindingResult bindingResult) {
 		memberValidator.validate(memberForm, bindingResult);


### PR DESCRIPTION
… war der Member Controller, der eine Methode beinhaltet hat, die auf alle Post-Anfragen hört. Da damit alle anderen Anfragen, die nicht explizit gemappt wurden, als nicht zulässig eingestuft wurden, wurde der Aufruf von /webjars/** geblockt und mit einem 405 - Method not allowed geantwortet. Der Fix liegt letztendlich nur in der Angabe eines Pfades in der Controller-Methode.